### PR TITLE
add support for Eufy Floodlight Camera

### DIFF
--- a/enums/device_type.js
+++ b/enums/device_type.js
@@ -3,6 +3,7 @@ exports.DeviceType = {
   VIDEO_DOORBELL_2K_POWERED: 'T8200',
   VIDEO_DOORBELL_2K_BATTERY: 'T8210',
   EUFYCAM_2_PRO: 'T8140',
+  FLOODLIGHT_CAMERA: 'T8420'
 }
 
-exports.supportedDevices = ['T8200', 'T8210', 'T814X']
+exports.supportedDevices = ['T8200', 'T8210', 'T814X', 'T8420']

--- a/enums/notification_type.js
+++ b/enums/notification_type.js
@@ -2,4 +2,5 @@ module.exports = {
   DOORBELL_PRESSED: 3103, // payload.payload.event_type OR payload.doorbell.event_type
   DOORBELL_SOMEONE_SPOTTED: 3102, // payload.payload.event_type OR payload.doorbell.event_type
   CAM_SOMEONE_SPOTTED: 14, // payload.type
+  FLOODLIGHT_MOTION_DETECTED: 3
 }

--- a/mqtt/client.js
+++ b/mqtt/client.js
@@ -85,6 +85,9 @@ class MqttClient {
       case NotificationType.CAM_SOMEONE_SPOTTED:
         await this.motionDetectedEvent(notification)
         break
+      case NotificationType.FLOODLIGHT_MOTION_DETECTED:
+        await this.motionDetectedEvent(notification)
+        break
     }
   }
 
@@ -131,8 +134,11 @@ class MqttClient {
       if (!device_sn) {
         device_sn = get(event, 'payload.doorbell.device_sn')
         if (!device_sn) {
-          winston.warn(`Got motionDetectedEvent with unknown device_sn`, { event })
-          return
+          device_sn = get(event, 'payload.station_sn')
+          if (!device_sn) {
+            winston.warn(`Got motionDetectedEvent with unknown device_sn`, { event })
+            return
+          }
         }
       }
     }

--- a/mqtt/ha-discovery.js
+++ b/mqtt/ha-discovery.js
@@ -6,7 +6,7 @@ class HaDiscovery {
     let configs = []
     const deviceType = device.type
 
-    if ([DeviceType.EUFYCAM_2_PRO, DeviceType.VIDEO_DOORBELL_2K_BATTERY].includes(deviceType)) {
+    if ([DeviceType.EUFYCAM_2_PRO, DeviceType.VIDEO_DOORBELL_2K_BATTERY, DeviceType.FLOODLIGHT_CAMERA].includes(deviceType)) {
       // Motion detected
       configs.push({
         topic: `homeassistant/binary_sensor/eufy/${device.id}_motion/config`,


### PR DESCRIPTION
note: since the payload has a blank `device_sn`, I swap the `station_sn` for `device_sn` in `MqttClient.motionDetectedEvent`. I'm not sure how this may affect other devices.