### PR TITLE
Update ha-discovery.js for INDOOR_CAM_PAN_TILT

### DIFF
--- a/mqtt/ha-discovery.js
+++ b/mqtt/ha-discovery.js
@@ -14,7 +14,7 @@ class HaDiscovery {
       DeviceType.EUFYCAM_2,
       DeviceType.EUFYCAM_2C_PRO,
       DeviceType.INDOOR_CAM,
-	    DeviceType.INDOOR_CAM_PAN_TILT,
+      DeviceType.INDOOR_CAM_PAN_TILT,
       DeviceType.VIDEO_DOORBELL_2K_BATTERY,
       DeviceType.VIDEO_DOORBELL_2K_POWERED,
       DeviceType.FLOODLIGHT_CAMERA,
@@ -38,6 +38,7 @@ class HaDiscovery {
       DeviceType.EUFYCAM_2,
       DeviceType.EUFYCAM_2C_PRO,
       DeviceType.INDOOR_CAM,
+      DeviceType.INDOOR_CAM_PAN_TILT,
       DeviceType.VIDEO_DOORBELL_2K_BATTERY,
       DeviceType.VIDEO_DOORBELL_2K_POWERED,
       DeviceType.FLOODLIGHT_CAMERA
@@ -48,6 +49,7 @@ class HaDiscovery {
     // Crying detected
     if ([
       DeviceType.INDOOR_CAM,
+      DeviceType.INDOOR_CAM_PAN_TILT,
     ].includes(deviceType)) {
       configs.push(this.cryingDetectedConfiguration(device.name, deviceSN))
     }
@@ -55,6 +57,7 @@ class HaDiscovery {
     // Sound detected
     if ([
       DeviceType.INDOOR_CAM,
+      DeviceType.INDOOR_CAM_PAN_TILT,
     ].includes(deviceType)) {
       configs.push(this.soundDetectedConfiguration(device.name, deviceSN))
     }


### PR DESCRIPTION
The "INDOOR_CAM_PAN_TILT" has the same functions/capabilities as the standard "INDOOR_CAM", so this change is to add the Indoor PAT everywhere that has the Indoor but missing the Indoor PAT entry.  From my review of the files I think this is the only file that needs to be updated.

Example....
DeviceType.INDOOR_CAM,
DeviceType.INDOOR_CAM_PAN_TILT,