### PR TITLE
add device 'T8111' EUFYCAM_1

### DIFF
--- a/enums/device_type.js
+++ b/enums/device_type.js
@@ -3,6 +3,7 @@ const { SensorType } = require('./sensor_type')
 
 const deviceType = {
   DOOR_SENSOR: 'T8900',
+  EUFYCAM_1: 'T8111',
   EUFYCAM_2: 'T8114',
   EUFYCAM_2C: 'T8113',
   EUFYCAM_2C_PRO: 'T8142',
@@ -23,6 +24,12 @@ const deviceType = {
 const capabilities = {
   [deviceType.DOOR_SENSOR]: [
     NotificationType.DOOR_SENSOR_CHANGED,
+    SensorType.BATTERY_PERCENTAGE,
+  ],
+  [deviceType.EUFYCAM_1]: [
+    NotificationType.EVENT_MOTION_DETECTED,
+    NotificationType.EVENT_PERSON_DETECTED,
+    NotificationType.THUMBNAIL,
     SensorType.BATTERY_PERCENTAGE,
   ],
   [deviceType.EUFYCAM_2]: [

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ are automatically discovered in Home Assistant.
 
 |   | Motion detected | Person detected | Doorbell press | Crying detected | Sound detected | Pet detected | Thumbnail last event | Battery status |
 |--|--|--|--|--|--|--|--|--|
+| Eufy Cam 1 (T8111) | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
 | Eufy Cam 2 (T8114) | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
 | Eufy Cam 2 Pro (T8140) | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
 | Eufy Cam 2C (T8113) | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |


### PR DESCRIPTION
Hi @matijse ,

I found that my "original contributor EUFYCAM" (EufyCAM 1, I suppose) - is not supported.

```
info: Stored device: Kamera Haustür (T8111H221839017B - type: T8111) {"timestamp":"2021-02-14T11:30:09.566Z"}
warn: DEVICE Kamera Haustür NOT SUPPORTED! See: https://github.com/matijse/eufy-ha-mqtt-bridge/issues/7 {"timestamp":"2021-02-14T11:30:09.568Z"}
```

here is a pull request to add this "T8111" device - and I hope I did everything correctly.