### PR TITLE
T8142-Z: Add new version/type of 2C Pro camera

### DIFF
--- a/enums/device_type.js
+++ b/enums/device_type.js
@@ -7,6 +7,7 @@ const deviceType = {
   EUFYCAM_2: 'T8114',
   EUFYCAM_2C: 'T8113',
   EUFYCAM_2C_PRO: 'T8142',
+  EUFYCAM_2C_PRO_Z: 'T8142-Z',
   EUFYCAM_2_PRO: 'T8140',
   EUFYCAM_E: 'T8112',
   FLOODLIGHT_CAMERA: 'T8420',
@@ -45,6 +46,12 @@ const capabilities = {
     SensorType.BATTERY_PERCENTAGE,
   ],
   [deviceType.EUFYCAM_2C_PRO]: [
+    NotificationType.EVENT_MOTION_DETECTED,
+    NotificationType.EVENT_PERSON_DETECTED,
+    NotificationType.THUMBNAIL,
+    SensorType.BATTERY_PERCENTAGE,
+  ],
+  [deviceType.EUFYCAM_2C_PRO_Z]: [
     NotificationType.EVENT_MOTION_DETECTED,
     NotificationType.EVENT_PERSON_DETECTED,
     NotificationType.THUMBNAIL,

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ are automatically discovered in Home Assistant.
 | Eufy Cam 2 (T8114) | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
 | Eufy Cam 2 Pro (T8140) | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
 | Eufy Cam 2C (T8113) | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
-| Eufy Cam 2C Pro (T8142) | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
+| Eufy Cam 2C Pro (T8142/T8142-Z) | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
 | Eufy Cam E (T8112) | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
 | Floodlight Camera (T8420) | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :x: |
 | Indoor Cam 2K (T8400) | :heavy_check_mark: | :heavy_check_mark: | :x: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: |


### PR DESCRIPTION
Received error on starting service:
`{
    "message": "Stored device: Shed (T8142N########## - type: T8142-Z)",
    "level": "info",
    "timestamp": "2021-03-02T21:46:27.734Z"
}
{
    "message": "DEVICE Shed NOT SUPPORTED! See: https://github.com/matijse/eufy-ha-mqtt-bridge/issues/7",
    "level": "warn",
    "timestamp": "2021-03-02T21:46:27.734Z"
}`

Type T8142-Z isnt in device_type.js, appears to be a revision for Eufy 2C Pro with the same capabilities, so ive added this (but not sure its the best approach so please do amend if there is a better way!)

Example trigger:

`"pushMessage": {
        "id": "1C669F31",
        "from": "348804314802",
        "to": "fIsfrs2tCRg-yl5iOlQbfc",
        "category": "com.oceanwing.battery.cam",
        "persistentId": "0:1614722641316589%0d2a775cf9fd7ecd",
        "ttl": 3600,
        "sent": "1614722641307",
        "payload": {
            "device_sn": "T8142N##########",
            "payload": {
                "a": 1,
                "s": "T8142N##########",
                "c": 1,
                "i": "0",
                "k": 137,
                "create_time": 1614722640598,
                "session_id": "20210302_220400",
                "notification_style": 1,
                "push_count": 1,
                "p": "20210302220358",
                "n": "Garden"
            },
            "station_sn": "T8142N##########",
            "google.c.sender.id": "348804314802",
            "type": "15",
            "title": "",
            "push_time": "1614722641300",
            "content": "Garden:Someone has been spotted",
            "event_time": "1614722640598"
        }
    }`


